### PR TITLE
Fixed ui-route link

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 						<li><a href="http://angular-ui.github.com/bootstrap/">Bootstrap</a></li>
 						<li><a href="http://angular-ui.github.com/ng-grid/">Grid</a></li>
 						<li><a href="https://github.com/angular-ui/AngularJs.tmbundle">AngularJS.tmbundle</a></li>
-						<li><a href="http://angular-ui.github.com/router/">Router <span class="label label-success">New!</span></a></li>
+						<li><a href="http://angular-ui.github.com/ui-router/">Router <span class="label label-success">New!</span></a></li>
 						<li><a href="http://angular-ui.github.com/Tips-n-Tricks/">Tips-n-Tricks <span class="label">WIP</span></a></li>
 					</ul>
 				</div>


### PR DESCRIPTION
Broken link:
The "ui-router" link in the main menu, here:
http://angular-ui.github.com/index.html
(in "Related projects")
points to /router instead of /ui-router
