### PR TITLE
Officially deprecate ui-select2 in favor of ui-select

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,11 @@
               </a>
             </li>
             <li>
+              <a href="https://github.com/angular-ui/ui-select">
+                UI-Select
+              </a>
+            </li>
+            <li>
               <a href="http://angular-ui.github.io/#ide-plugins">
                 IDE Plugins
               </a>
@@ -171,7 +176,7 @@
           </ul>
           <ul class="nav nav-tabs nav-stacked span6">
             <li><a href="http://github.com/angular-ui/ui-date">Date</a></li>
-            <li><a href="http://github.com/angular-ui/ui-select2">Select2</a></li>
+            <li><a href="http://github.com/angular-ui/ui-select2"><s>Select2</s></a> - deprecated, use UI-Select instead</li>
             <li><a href="http://github.com/angular-ui/ui-tinymce">TinyMCE</a></li>
             <li><a href="http://github.com/angular-ui/ui-sortable">Sortable</a></li>
           </ul>
@@ -213,6 +218,15 @@
           <span class="btn-group pull-right">
             <a class="btn btn-primary btn-large" href="http://angular-ui.github.io/ui-router/sample">Site</a>
             <a class="btn btn-inverse btn-large" href="https://github.com/angular-ui/ui-router">Code</a>
+          </span>
+        </h1>
+      </section>
+      <section>
+        <h1 class="page-header">
+          UI-Select
+          <small>AngularJS-native version of Select2 and Selectize</small>
+          <span class="btn-group pull-right">
+            <a class="btn btn-inverse btn-large" href="https://github.com/angular-ui/ui-select">Code</a>
           </span>
         </h1>
       </section>


### PR DESCRIPTION
Following the deprecation of ui-select2, promote ui-select as replacement
