### PR TITLE
Fixing ui-router link

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
           UI-Router
           <small>Nested Routing for AngularJS</small>
           <span class="btn-group pull-right">
-            <a class="btn btn-primary btn-large" href="http://angular-ui.github.io/ui-router/sample">Site</a>
+            <a class="btn btn-primary btn-large" href="http://angular-ui.github.io/ui-router/site">Site</a>
             <a class="btn btn-inverse btn-large" href="https://github.com/angular-ui/ui-router">Code</a>
           </span>
         </h1>


### PR DESCRIPTION
The link to "ui-router > site" goes to the wrong place.
